### PR TITLE
Removing redundant electron type defs from deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
   "homepage": "https://github.com/irath96/electron-react-typescript-boilerplate#readme",
   "devDependencies": {
     "@types/chai": "^3.4.34",
-    "@types/electron": "^1.4.30",
     "@types/enzyme": "^2.5.39",
     "@types/jsdom": "^2.0.29",
     "@types/mocha": "^2.2.34",


### PR DESCRIPTION
Looks like electron-prebuilt now includes it's own type defs, just added a few days ago: https://github.com/electron-userland/electron-prebuilt/blob/master/electron.d.ts. The @types/electron dev dependency in package.json now causes build failures due to duplicate type definitions.

To repro just create a fresh clone, `npm install` then `npm run dev`.