### PR TITLE
fix(package): Put directories to the correct config place

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,10 @@
       "main.js.map",
       "package.json"
     ],
+    "directories": {
+      "buildResources": "resources",
+      "output": "release"
+    },
     "win": {
       "target": "nsis"
     },
@@ -79,10 +83,6 @@
         "AppImage"
       ]
     }
-  },
-  "directories": {
-    "buildResources": "resources",
-    "output": "release"
   },
   "bin": {
     "electron": "./node_modules/.bin/electron"


### PR DESCRIPTION
The `directories` config section needs to reside in the `build` part. (As of the documentation of the builder)