### PR TITLE
fix; SecurityError: localStorage is not available for opaque origins

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "cleanup": "mop -v"
   },
   "jest": {
+    "testURL": "http://localhost/",
     "moduleNameMapper": {
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/internals/mocks/fileMock.js",
       "\\.(css|less|sass|scss)$": "identity-obj-proxy"


### PR DESCRIPTION
`npm run test` and `npm run test-e2e` fails with:

```
 FAIL  test/containers/CounterPage.spec.tsx
  ● Test suite failed to run

    SecurityError: localStorage is not available for opaque origins

      at Window.get localStorage [as localStorage] (node_modules/jsdom/lib/jsdom/browser/Window.js:257:15)
          at Array.forEach (<anonymous>)

```
